### PR TITLE
centralized options retrieval

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,3 @@
+# UNIT TEST configuration file
+# the github repository for a pattern library
+githubrepo: 'pattern-library-utilities'

--- a/lib/clone-pattern.js
+++ b/lib/clone-pattern.js
@@ -16,7 +16,8 @@ var PLUGIN_NAME = 'pattern-importer';
 exports.patternCloner = function (options) {
   'use strict';
 
-  options = utility.getPatternUtilOptions(options);
+  // check options
+  options = options || utility.getProjectOptions();
 
   var stream = through.obj(function (file, encoding, cb) {
 

--- a/lib/get-options.js
+++ b/lib/get-options.js
@@ -9,6 +9,8 @@
 var merge = require('lodash.merge');
 var fs = require('fs');
 var path = require('path');
+var convertYaml = require('./convert-yaml');
+var convertJson = require('./convert-recursive-json-variables');
 var utility = require('./utility');
 var gutil = require('gulp-util');
 var PLUGIN_NAME = 'Pattern Library Utilities';
@@ -57,12 +59,58 @@ var getDefaultPatternUtilOptions = exports.getDefaultPatternUtilOptions = functi
     templateEngine: 'twig',
     convertCategoryTitles: true, // default: true
     convertCategoryTitlesDataFile: path.join(__dirname, '../lib/data/pattern-lab-categories.yml'),
-    uncategorizedDir: 'uncategorized'
+    uncategorizedDir: 'uncategorized',
+    defaultConfigFile: './config.yml'
   };
 
   return options;
 };
 
+/**
+ * Returns project's options
+ *
+ * @param  {string}  configFile  configuration file path
+ * @param  {string}  cwd  current working directory path
+ *
+ * @return {Object}  options  an object of combined default/project-defined Pattern Library Utilities options
+ */
+exports.getProjectOptions = function (configFile, cwd) {
+
+  var projectOptions = '';
+  var defaultConfig = getDefaultPatternUtilOptions();
+
+  // figure out the default configuration file
+  configFile = configFile || defaultConfig.defaultConfigFile;
+
+  // figure out the current working directory
+  cwd = cwd || process.cwd();
+
+  // attempt to synchronously open the yaml configuration file
+  try {
+    // open the configuration file
+    projectOptions = fs.readFileSync(path.join(cwd, configFile), {encoding: 'utf8'});
+  }
+  catch (e) {
+    console.log('No config file found', e);
+  }
+
+  if (projectOptions) {
+    // convert configuration file to JS Object
+    var configObject = convertYaml.convertYamlToObject(projectOptions);
+
+    // regex to search for variables
+    var variableRegex = /{{.*}}/g;
+
+    // convert variables
+    projectOptions = convertJson.convertRecursiveJsonVariables(configObject, variableRegex);
+  }
+
+  // merge
+  var options = mergeOptions(defaultConfig, projectOptions);
+
+  // test options and return final options object
+  return testProjectOptions(options);
+}
 
 /**
  * Function to test the final options for incorrect data types
@@ -71,10 +119,8 @@ var getDefaultPatternUtilOptions = exports.getDefaultPatternUtilOptions = functi
  *
  * @return {Object}  options  an object of all default Pattern Library Utilities options
  */
-exports.getPatternUtilOptions = function (projectOptions) {
+var testProjectOptions = exports.testProjectOptions = function (options) {
   'use strict';
-
-  var options = mergeOptions(getDefaultPatternUtilOptions(), projectOptions);
 
   // Source for data object used to populate patterns. 'pattern' means data is coming from the dataFileName file
   if (typeof options.dataSource !== 'string') {

--- a/lib/pattern-importer.js
+++ b/lib/pattern-importer.js
@@ -12,8 +12,8 @@ var PLUGIN_NAME = 'pattern-importer';
 exports.patternImporter = function (options) {
   'use strict';
 
-  // merge project options with default options
-  options = utility.getPatternUtilOptions(options);
+  // check options
+  options = options || utility.getProjectOptions();
 
   var stream = through.obj(function (file, encoding, cb) {
 

--- a/test/fixtures/config.yml
+++ b/test/fixtures/config.yml
@@ -1,0 +1,5 @@
+# TEST configuration file
+# source for data injected into patterns
+dataSource: 'spiderpig'
+# random extra piece of data
+testChange: 'Does whatever he does'

--- a/test/main.js
+++ b/test/main.js
@@ -15,6 +15,7 @@ var createTestFilePath = function(filePath) {
 
 };
 
+var testConfigFile = './test/fixtures/config.yml';
 // create our options
 var options = {
   dataFileName: 'pattern.yml',
@@ -112,25 +113,41 @@ describe('pattern utilities', function () {
 
   it('should return default options', function () {
 
-    var file = utils.createFile(createTestFilePath('test-elm-h1/pattern.yml'));
     var defaultOptions = utils.getDefaultPatternUtilOptions();
 
     defaultOptions.should.have.property('dataSource', 'pattern');
     defaultOptions.should.have.property('dataFileName', 'pattern.yml');
+    defaultOptions.should.have.property('localPatternsDir', './patterns');
 
   });
 
-  it('should return default options', function () {
+  it('should return project options when told the configuration file', function () {
 
-    var file = utils.createFile(createTestFilePath('test-elm-h1/pattern.yml'));
-    options.dataFileName = 'spiderpig.yml' // change data filename
-    options.testChange = 'Does whatever he does';
-    var mergedOptions = utils.getPatternUtilOptions(options);
+    var mergedOptions = utils.getProjectOptions(testConfigFile);
 
-    mergedOptions.should.have.property('dataFileName', 'spiderpig.yml');
+    mergedOptions.should.have.property('dataSource', 'spiderpig');
     mergedOptions.should.have.property('testChange', 'Does whatever he does');
+    mergedOptions.should.have.property('localPatternsDir', './patterns');
 
-    options.dataFileName = 'pattern.yml' // return it to default
+  });
+
+  it('should return project options with a known CWD, but unknown configuration file', function () {
+
+    var mergedOptions = utils.getProjectOptions('','./test/fixtures');
+
+    mergedOptions.should.have.property('dataSource', 'spiderpig');
+    mergedOptions.should.have.property('testChange', 'Does whatever he does');
+    mergedOptions.should.have.property('localPatternsDir', './patterns');
+
+  });
+
+  it('should return project options with a unknown CWD and unknown configuration file', function () {
+
+    var mergedOptions = utils.getProjectOptions();
+
+    mergedOptions.should.have.property('dataSource', 'pattern');
+    mergedOptions.should.have.property('localPatternsDir', './patterns');
+    mergedOptions.should.have.property('githubrepo', 'pattern-library-utilities');
 
   });
 


### PR DESCRIPTION
@e2tha-e 
cc: @rebmullin @sergesemashko @conortm @gvorbeck @beynya @nikkiana

This centralizes options retrieval. Should help with the logger *and* cleaning up the project gulpfile ([see PR in generator](https://github.com/pattern-library/generator-pattern-library/pull/9))

## in this PR

* new function `getProjectOptions` which
    * returns combined default/project options
    * can ingest a filepath, or find config from a default location
* unit tests / test files