### PR TITLE
Clone overwrite

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,8 +2,8 @@
   "extends": "eslint:recommended",
   "env": {
     "browser": true,
-    // "amd": true, // uncomment for node apps
-    // "node": true // uncomment for node apps
+    "amd": true, // uncomment for node apps
+    "node": true // uncomment for node apps
   },
   "globals": {
     "Drupal": true,

--- a/lib/clone-pattern.js
+++ b/lib/clone-pattern.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var fs = require('fs-extra');
 var utility = require('./utility');
+var log = require('./logger').logger;
 var through = require('through2');
 var gutil = require('gulp-util');
 var PluginError = gutil.PluginError;
@@ -25,7 +26,7 @@ exports.patternCloner = function (options) {
       return cb();
     }
     if (file.isStream()) {
-      this.emit('error', new PluginError(PLUGIN_NAME, 'Streams not supported'));
+      log.error('error', new PluginError(PLUGIN_NAME, 'Streams not supported'));
       return cb();
     }
 
@@ -56,7 +57,8 @@ exports.testIfSinglePattern = function (patternPath, options) {
   options = options || utility.getProjectOptions();
 
   if (typeof patternPath !== 'string') {
-    throw new Error('Pattern path must be a string');
+    log.error('Pattern path must be a string');
+    return;
   }
 
   // check that the patternPath ends with the dataFileName (pattern.yml); if not, add it to the path
@@ -69,8 +71,8 @@ exports.testIfSinglePattern = function (patternPath, options) {
     fs.statSync(patternPath);
   }
   catch (e) {
-    console.log("Pattern data file does not exist.");
-    console.log(e);
+    log.error(options.dataFileName + ' does not exist at ' + patternPath);
+    log.error(e);
     return;
   }
 
@@ -90,7 +92,8 @@ exports.clonePattern = function (paths, options, destDir, cb) {
   // make sure the destination directory is a string and exists
   destDir = destDir || './patterns';
   if (typeof destDir !== 'string') {
-    throw new Error('Destination directory must be a string.');
+    log.error('Destination directory must be a string.');
+    throw new Error();
   }
 
   // open the pattern's data file
@@ -111,12 +114,12 @@ exports.clonePattern = function (paths, options, destDir, cb) {
   }
   catch (e) {
     copyPatternDir(paths, clonedPatternDest, options, cb);
-    return
+    return;
   }
 
   // check if overwrite is allowed
   if (!options.config.overwrite) {
-    utility.log('A pattern directory for ' + paths.directory + ' already exists in ' + clonedPatternDest);
+    log.info('A pattern directory for ' + paths.directory + ' already exists in ' + clonedPatternDest);
     return;
   }
 
@@ -135,13 +138,14 @@ exports.clonePattern = function (paths, options, destDir, cb) {
  *
 */
 var copyPatternDir = function (paths, dest, options, cb) {
+  'use strict';
 
   // copy the entire pattern directory, as-is, to our destination directory
   fs.copy(String(paths.folder), dest, function (err) {
-    if (err && err.code !== 'ENOENT') {return utility.error(err); }
+    if (err && err.code !== 'ENOENT') {return log.error(err); }
 
     // success in cloning the directory
-    utility.logger(paths.directory + ' pattern cloned into ' + dest);
+    log.info(paths.directory + ' pattern cloned into ' + dest);
 
     // create the cloned pattern's data file's path
     var clonedPatternYmlFile = paths.relative;
@@ -158,11 +162,11 @@ var copyPatternDir = function (paths, dest, options, cb) {
     // overwrite the cloned pattern's data file with the adjusted contents
     fs.writeFile(clonedPatternYmlFile, newDataFileContents, function (err) {
       if (err) { throw err; }
-      utility.log(clonedPatternYmlFile + 'cloned source added to ' + options.dataFileName);
+      log.info(clonedPatternYmlFile + ' cloned source added to ' + options.dataFileName);
       cb();
     });
   });
-}
+};
 
 /*
  * Add data about a cloned pattern's source

--- a/lib/clone-pattern.js
+++ b/lib/clone-pattern.js
@@ -49,19 +49,19 @@ exports.patternCloner = function (options) {
  *
  * @return {Object} path to a patternDataFile (pattern.yml)
 */
-exports.testIfSinglePattern = function (patternPath) {
+exports.testIfSinglePattern = function (patternPath, options) {
   'use strict';
 
-  // get project options
-  var projectOptions = utility.getPatternUtilOptions();
+  // check options
+  options = options || utility.getProjectOptions();
 
   if (typeof patternPath !== 'string') {
     throw new Error('Pattern path must be a string');
   }
 
   // check that the patternPath ends with the dataFileName (pattern.yml); if not, add it to the path
-  if (path.basename(patternPath) !== projectOptions.dataFileName) {
-    patternPath = path.join(patternPath, projectOptions.dataFileName);
+  if (path.basename(patternPath) !== options.dataFileName) {
+    patternPath = path.join(patternPath, options.dataFileName);
   }
 
   // test for existence of patternDataFile
@@ -84,7 +84,7 @@ exports.testIfSinglePattern = function (patternPath) {
  * @param {Object} options  pattern-importer options
  * @param {String} destDir  the top of destination directory for the cloned pattern
 */
-exports.clonePattern = function (paths, options, destDir, callback) {
+exports.clonePattern = function (paths, options, destDir, cb) {
   'use strict';
 
   // make sure the destination directory is a string and exists
@@ -105,49 +105,64 @@ exports.clonePattern = function (paths, options, destDir, callback) {
   // determine the cloned pattern's destination directory inside the local patterns directory
   var clonedPatternDest = path.resolve(path.join(destDir, patternCategoryPath, paths.directory));
 
-  // default flag is to check if the folder can be read (and is thus there)
-  var openFlags = 'r';
-  if (options.overwrite) {
-    openFlags = 'rw'; // now checks if it is writable (thus overwrite-able)
+  // if the destination directory doesn't exist, just copy the pattern
+  try {
+    fs.statSync(clonedPatternDest);
   }
-  // check if a directory already exists in our destination
-  fs.open(clonedPatternDest, openFlags, function (err, fd) {
-    if (err && err.code === 'ENOENT') {
+  catch (e) {
+    copyPatternDir(paths, clonedPatternDest, options, cb);
+    return
+  }
 
-      // copy the entire pattern directory, as-is, to our destination directory
-      fs.copy(paths.folder, clonedPatternDest, function (err) {
-        if (err) { return utility.error(err); }
+  // check if overwrite is allowed
+  if (!options.config.overwrite) {
+    utility.log('A pattern directory for ' + paths.directory + ' already exists in ' + clonedPatternDest);
+    return;
+  }
 
-        // success in cloning the directory
-        utility.log(paths.directory + ' pattern cloned into ' + clonedPatternDest);
-
-        // create the cloned pattern's data file's path
-        var clonedPatternYmlFile = path.join(clonedPatternDest, options.dataFileName);
-
-        // open the cloned pattern's data file
-        var clonedPatternYml = fs.readFileSync(clonedPatternYmlFile, {encoding: 'utf8'});
-
-        // get metadata from the data file
-        var clonedPatternObject = utility.convertYamlToObject(clonedPatternYml);
-
-        // new file contents
-        var newDataFileContents = utility.convertObjectToYaml(addCloneSource(paths, clonedPatternObject));
-
-        // overwrite the cloned pattern's data file with the adjusted contents
-        fs.writeFile(clonedPatternYmlFile, newDataFileContents, function (err) {
-          if (err) { throw err; }
-          utility.log(clonedPatternYmlFile + 'cloned source added to ' + options.dataFileName);
-          callback();
-        });
-      });
-    }
-    else {
-      utility.log('A pattern directory for ' + paths.directory + ' already exists in ' + clonedPatternDest);
-      callback();
-    }
-  });
+  // copy the pattern
+  copyPatternDir(paths, clonedPatternDest, options, cb);
 
 };
+
+/*
+ * Copy the pattern directory and adjust it's data file
+ *
+ * @param {String} paths  pattern source
+ * @param {String} dest  destination for pattern
+ * @param {Object} options  project options
+ * @param {Func} cb  callback function
+ *
+*/
+var copyPatternDir = function (paths, dest, options, cb) {
+
+  // copy the entire pattern directory, as-is, to our destination directory
+  fs.copy(String(paths.folder), dest, function (err) {
+    if (err && err.code !== 'ENOENT') {return utility.error(err); }
+
+    // success in cloning the directory
+    utility.logger(paths.directory + ' pattern cloned into ' + dest);
+
+    // create the cloned pattern's data file's path
+    var clonedPatternYmlFile = paths.relative;
+
+    // open the cloned pattern's data file
+    var clonedPatternYml = fs.readFileSync(clonedPatternYmlFile, {encoding: 'utf8'});
+
+    // get metadata from the data file
+    var clonedPatternObject = utility.convertYamlToObject(clonedPatternYml);
+
+    // new file contents
+    var newDataFileContents = utility.convertObjectToYaml(addCloneSource(paths, clonedPatternObject));
+
+    // overwrite the cloned pattern's data file with the adjusted contents
+    fs.writeFile(clonedPatternYmlFile, newDataFileContents, function (err) {
+      if (err) { throw err; }
+      utility.log(clonedPatternYmlFile + 'cloned source added to ' + options.dataFileName);
+      cb();
+    });
+  });
+}
 
 /*
  * Add data about a cloned pattern's source

--- a/lib/clone-pattern.js
+++ b/lib/clone-pattern.js
@@ -105,8 +105,13 @@ exports.clonePattern = function (paths, options, destDir, callback) {
   // determine the cloned pattern's destination directory inside the local patterns directory
   var clonedPatternDest = path.resolve(path.join(destDir, patternCategoryPath, paths.directory));
 
+  // default flag is to check if the folder can be read (and is thus there)
+  var openFlags = 'r';
+  if (options.overwrite) {
+    openFlags = 'rw'; // now checks if it is writable (thus overwrite-able)
+  }
   // check if a directory already exists in our destination
-  fs.open(clonedPatternDest, 'r', function (err, fd) {
+  fs.open(clonedPatternDest, openFlags, function (err, fd) {
     if (err && err.code === 'ENOENT') {
 
       // copy the entire pattern directory, as-is, to our destination directory

--- a/lib/get-options.js
+++ b/lib/get-options.js
@@ -11,7 +11,6 @@ var fs = require('fs');
 var path = require('path');
 var convertYaml = require('./convert-yaml');
 var convertJson = require('./convert-recursive-json-variables');
-var utility = require('./utility');
 var gutil = require('gulp-util');
 var PLUGIN_NAME = 'Pattern Library Utilities';
 
@@ -75,6 +74,7 @@ var getDefaultPatternUtilOptions = exports.getDefaultPatternUtilOptions = functi
  * @return {Object}  options  an object of combined default/project-defined Pattern Library Utilities options
  */
 exports.getProjectOptions = function (configFile, cwd) {
+  'use strict';
 
   var projectOptions = '';
   var defaultConfig = getDefaultPatternUtilOptions();
@@ -110,12 +110,12 @@ exports.getProjectOptions = function (configFile, cwd) {
 
   // test options and return final options object
   return testProjectOptions(options);
-}
+};
 
 /**
  * Function to test the final options for incorrect data types
  *
- * @param  {object}  projectOptions  the project's options
+ * @param  {object}  options  the project's options
  *
  * @return {Object}  options  an object of all default Pattern Library Utilities options
  */
@@ -189,7 +189,7 @@ var testProjectOptions = exports.testProjectOptions = function (options) {
       // If the type is not what you want, then just throw the error again.
       throw new gutil.PluginError(PLUGIN_NAME, 'Error opening category title-conversion data file: ' + options.convertCategoryTitlesDataFile + '\n Error: ' + err);
     }
-    options.convertCategoryTitlesData = utility.convertYamlToObject(convertCategoryTitlesDataFile);
+    options.convertCategoryTitlesData = convertYaml.convertYamlToObject(convertCategoryTitlesDataFile);
   }
 
   // determine css compiler

--- a/lib/gulp-tasks/clone.js
+++ b/lib/gulp-tasks/clone.js
@@ -10,6 +10,7 @@
 var utility = require('../utility');
 var mergeOptions = require('../get-options').mergeOptions;
 var minimist = require('minimist');
+var log = require('../logger').logger;
 
 /**
  * Function to get default options for an implementation of a clone-pattern task
@@ -34,17 +35,17 @@ var checkForClassArguments = function (args) {
   'use strict';
 
   if (!args.pattern) {
-    utility.log('To clone, you must include a pattern flag. example: "--pattern /path/to/pattern/directory"');
+    log.warn('To clone, you must include a pattern flag. example: "--pattern /path/to/pattern/directory"');
     return false;
   }
 
   if (typeof args.pattern !== 'string') {
-    utility.log('The path to the pattern-to-clone must be a string.');
+    log.warn('The path to the pattern-to-clone must be a string.');
     return false;
   }
 
-  if (args.overwrite && ((typeof args.overwrite !== 'string') || (args.overwrite !=='YES'))) {
-    utility.log('You must type YES in all caps to overwrite your local pattern');
+  if (args.overwrite && ((typeof args.overwrite !== 'string') || (args.overwrite !== 'YES'))) {
+    log.warn('You must type YES in all caps to overwrite your local pattern');
     return false;
   }
 
@@ -68,27 +69,29 @@ var checkForClassArguments = function (args) {
 exports.gulpClonePattern = function (gulp, projectOptions) {
   'use strict';
 
-  var projectOptions = mergeOptions(getDefaultOptions(), projectOptions);
+  var patternDataFile;
+
+  projectOptions = mergeOptions(getDefaultOptions(), projectOptions);
 
   var options = utility.getProjectOptions();
 
-  var options = mergeOptions(options, projectOptions);
+  options = mergeOptions(options, projectOptions);
 
   gulp.task(options.taskName, options.dependencies, function () {
 
     var args = checkForClassArguments(minimist(process.argv.slice(2)));
 
     if (!args) {
-      console.log('Exiting without cloning.');
+      log.error('Exiting without cloning.');
       return;
     }
 
     // single pattern cloning
     if (args.pattern) {
-      var patternDataFile = utility.testIfSinglePattern(args.pattern, options);
+      patternDataFile = utility.testIfSinglePattern(args.pattern, options);
 
       if (!patternDataFile) {
-        utility.log('The pattern you want to clone does not exist. Exiting without cloning.');
+        log.error('The pattern you want to clone does not exist. Exiting without cloning.');
         return;
       }
     }
@@ -97,7 +100,7 @@ exports.gulpClonePattern = function (gulp, projectOptions) {
     if (args.overwrite) {
       options.config = {
         overwrite: true
-      }
+      };
     }
 
 

--- a/lib/gulp-tasks/clone.js
+++ b/lib/gulp-tasks/clone.js
@@ -34,17 +34,17 @@ var checkForClassArguments = function (args) {
   'use strict';
 
   if (!args.pattern) {
-    console.log('To clone, you must include a pattern flag. example: "--pattern /path/to/pattern/directory"');
+    utility.log('To clone, you must include a pattern flag. example: "--pattern /path/to/pattern/directory"');
     return false;
   }
 
   if (typeof args.pattern !== 'string') {
-    console.log('The path to the pattern-to-clone must be a string.');
+    utility.log('The path to the pattern-to-clone must be a string.');
     return false;
   }
 
   if (args.overwrite && ((typeof args.overwrite !== 'string') || (args.overwrite !=='YES'))) {
-    console.log('You must type YES in all caps to overwrite your local pattern');
+    utility.log('You must type YES in all caps to overwrite your local pattern');
     return false;
   }
 
@@ -68,7 +68,11 @@ var checkForClassArguments = function (args) {
 exports.gulpClonePattern = function (gulp, projectOptions) {
   'use strict';
 
-  var options = mergeOptions(getDefaultOptions(), projectOptions);
+  var projectOptions = mergeOptions(getDefaultOptions(), projectOptions);
+
+  var options = utility.getProjectOptions();
+
+  var options = mergeOptions(options, projectOptions);
 
   gulp.task(options.taskName, options.dependencies, function () {
 
@@ -81,10 +85,10 @@ exports.gulpClonePattern = function (gulp, projectOptions) {
 
     // single pattern cloning
     if (args.pattern) {
-      var patternDataFile = utility.testIfSinglePattern(args.pattern);
+      var patternDataFile = utility.testIfSinglePattern(args.pattern, options);
 
       if (!patternDataFile) {
-        console.log('The pattern you want to clone does not exist. Exiting without cloning.');
+        utility.log('The pattern you want to clone does not exist. Exiting without cloning.');
         return;
       }
     }
@@ -98,7 +102,7 @@ exports.gulpClonePattern = function (gulp, projectOptions) {
 
 
     return gulp.src(patternDataFile)
-    .pipe(utility.patternCloner(options.config));
+    .pipe(utility.patternCloner(options));
 
   });
 

--- a/lib/gulp-tasks/clone.js
+++ b/lib/gulp-tasks/clone.js
@@ -43,7 +43,7 @@ var checkForClassArguments = function (args) {
     return false;
   }
 
-  if ((typeof args.overwrite !== 'string') || (args.overwrite !=='YES')) {
+  if (args.overwrite && ((typeof args.overwrite !== 'string') || (args.overwrite !=='YES'))) {
     console.log('You must type YES in all caps to overwrite your local pattern');
     return false;
   }
@@ -79,6 +79,7 @@ exports.gulpClonePattern = function (gulp, projectOptions) {
       return;
     }
 
+    // single pattern cloning
     if (args.pattern) {
       var patternDataFile = utility.testIfSinglePattern(args.pattern);
 
@@ -88,8 +89,11 @@ exports.gulpClonePattern = function (gulp, projectOptions) {
       }
     }
 
+    // overwrite option
     if (args.overwrite) {
-
+      options.config = {
+        overwrite: true
+      }
     }
 
 

--- a/lib/gulp-tasks/clone.js
+++ b/lib/gulp-tasks/clone.js
@@ -43,6 +43,11 @@ var checkForClassArguments = function (args) {
     return false;
   }
 
+  if ((typeof args.overwrite !== 'string') || (args.overwrite !=='YES')) {
+    console.log('You must type YES in all caps to overwrite your local pattern');
+    return false;
+  }
+
   return args;
 
 };
@@ -74,12 +79,19 @@ exports.gulpClonePattern = function (gulp, projectOptions) {
       return;
     }
 
-    var patternDataFile = utility.testIfSinglePattern(args.pattern);
+    if (args.pattern) {
+      var patternDataFile = utility.testIfSinglePattern(args.pattern);
 
-    if (!patternDataFile) {
-      console.log('No patternDataFile, exiting without cloning.');
-      return;
+      if (!patternDataFile) {
+        console.log('The pattern you want to clone does not exist. Exiting without cloning.');
+        return;
+      }
     }
+
+    if (args.overwrite) {
+
+    }
+
 
     return gulp.src(patternDataFile)
     .pipe(utility.patternCloner(options.config));

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -35,7 +35,7 @@ function getLoggerOptions() {
 
   // check if we're unit testing
   if (isTest()) {
-    options.logger.silent = true;
+    options.logger.level = 'warn';
   }
 
   // basic transports from options

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -4,27 +4,42 @@
  * If for any reason, they need a different logging tool or need to be extended,
  * the changes can be made here.
  */
-var mergeOptions = require('./get-options').mergeOptions;
+var getOptions = require('./get-options');
 var util = require('util');
-var utility = require('./utility');
 var winston = require('winston');
 
 /**
- * Abstracts fully-fleshed logging module to the logger property of this module.
+ * Get options for logging system. Checks project's options against defaults, and sets up Winston's transport requirements
  *
- * If logging with metadata, or requiring winston.log's more advanced features,
- * use exports.logger().log() instead of exports.log().
- * @example
- *   exports.logger().log('info', 'Test Log Message', { anything: 'This is metadata' });
- *
- * @return {Object} An instance of winston.Logger.
+ * @return {Object} Contains Winston-specific options for transports and exiting on errors.
  */
-exports.logger = function () {
+function getLoggerOptions() {
   'use strict';
 
-  var options = utility.getProjectOptions();
+  var defaultOptions = {
+    logger: {
+      level: 'info',
+      silent: false,
+      exitOnError: true,
+      logFile: ''
+    }
+  };
 
-  var transports = [
+  var loggerOptions = {};
+
+  // get the project's options
+  var projectOptions = getOptions.getProjectOptions();
+
+  // merge project options with default options; project options take precedence
+  var options = getOptions.mergeOptions(defaultOptions, projectOptions);
+
+  // check if we're unit testing
+  if (isTest()) {
+    options.logger.silent = true;
+  }
+
+  // basic transports from options
+  loggerOptions.transports = [
     new winston.transports.Console({
       level: options.logger.level,
       silent: options.logger.silent,
@@ -32,8 +47,9 @@ exports.logger = function () {
     })
   ];
 
+  // check if we should add a log file
   if (options.logger.logFile) {
-    transports.push(
+    loggerOptions.transports.push(
       new winston.transports.File({
         filename: options.logger.logFile,
         level: options.logger.level
@@ -41,20 +57,32 @@ exports.logger = function () {
     );
   }
 
-  var logger = new winston.Logger({
-    transports: transports,
-    exitOnError: options.logger.exitOnError
-  });
+  loggerOptions.exitOnError = options.logger.exitOnError;
 
-  return logger;
-};
+  return loggerOptions;
+
+}
+
+/**
+ * Instantiate winston
+ *
+ * Can use metadata at any logging level
+ * @example
+ *   var log = require('/path/to/this/logger.js');
+ *   // with metadata
+ *   log.info('Test Log Message', { anything: 'This is metadata' });
+ *   // general
+ *   log.info('Test Log Message');
+ *
+ */
+exports.logger = new winston.Logger(getLoggerOptions());
 
 /**
  * Checks if this utility is called from a unit test.
  *
  * @return {boolean} True or false.
  */
-exports.isTest = function () {
+function isTest() {
   'use strict';
 
   var isTest = false;
@@ -67,7 +95,7 @@ exports.isTest = function () {
   }
 
   return isTest;
-};
+}
 
 /**
  * Recursively prints the properties of an object.
@@ -87,37 +115,3 @@ exports.inspectObj = function (obj, showHidden, depth) {
     winston.info(obj);
   }
 };
-
-/**
- * The lazy dev's default method for this utility.
- *
- * Should be a drop-in replacement for console.log, although it can abstract
- * something more extensible like Winston. This logs at the info level. If run
- * from a unit test, this will not output anything.
- * Accepts the same parameters as the unabstracted tool's info() method.
- */
-exports.log = exports.isTest() ? function () { 'use strict'; } : winston.info;
-
-/**
- * @function info
- * Log at the info level.
- *
- * Accepts the same parameters as the unabstracted tool's info() method.
- */
-exports.info = winston.info;
-
-/**
- * @function warn
- * Log at the warn level.
- *
- * Accepts the same parameters as the unabstracted tool's warn() method.
- */
-exports.warn = winston.warn;
-
-/**
- * @function error
- * Log at the error level.
- *
- * Accepts the same parameters as the unabstracted tool's error() method.
- */
-exports.error = winston.error;

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -4,7 +4,8 @@
 
 var copy = require('copy-to');
 
-copy(require('./category-name-converter'))
+copy(require('./get-options'))
+.and(require('./category-name-converter'))
 .and(require('./clone-pattern'))
 .and(require('./compilers/css-compilers/sass-compiler'))
 .and(require('./compilers/html-compilers/twig-compiler'))

--- a/test/fixtures/test-elm-h1/pattern.yml
+++ b/test/fixtures/test-elm-h1/pattern.yml
@@ -5,6 +5,9 @@ sass: ./test-elm-h1.scss
 category: base
 subcategory: subcatbase
 script: ./test-elm-h1.js
+cloneSource:
+  path: test/fixtures/test-elm-h1
+  name: Heading Level 1 Test H1
 data:
   header:
     text: Test Header 1

--- a/test/main.js
+++ b/test/main.js
@@ -1,4 +1,5 @@
 var utils = require('../');
+var log = require('../lib/logger').logger;
 var should = require('should');
 var chai = require('chai');
 var expect = chai.expect;


### PR DESCRIPTION
@e2tha-e 
cc: @rebmullin @sergesemashko @conortm @gvorbeck @beynya @nikkiana

This PR is for [TA99424](https://rally1.rallydev.com/#/26707410139ud/detail/task/41508573767) - local overrides.

This allows the addition of a flag on `gulp clone` commands to allow overwriting the local version of a pattern - if it exists.

An overwrite clone statement would be like so:

```
gulp clone --pattern node_modules/pattern-library/patterns/atoms/text/h5 --overwrite YES
```

I've also made some slight adjustments to logger.js because I was running into errors when trying to use the system. Note: cannot get exitOnError to work - but otherwise logger works as expected.

thanks,
Scott