### PR TITLE
remove importing non-default patterns

### DIFF
--- a/lib/get-pattern-files.js
+++ b/lib/get-pattern-files.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var fs = require('fs');
+var log = require('./logger').logger;
 var utility = require('./utility');
 
 /*
@@ -53,6 +54,11 @@ exports.getPatternFiles = function (paths, options) {
 
     }
     else {
+
+      if (!patternObject[options.templateEngine]) {
+        log.warn('non-default templateEngine template found, import of ' + patternObject.name + 'skipped.');
+        return false;
+      }
 
       // no conversion
 

--- a/lib/get-pattern-styles.js
+++ b/lib/get-pattern-styles.js
@@ -1,5 +1,5 @@
 /*
- * Gets name and type of pattern style file. Defaults to .css file (if it exists)
+ * Gets name and type of pattern style file.
  *
  * @param {Object} patternObject  metadata from pattern data file (default: pattern.yml)
  * @param {Object} options  pattern-importer options
@@ -10,11 +10,9 @@
 */
 exports.getPatternStyles = function (patternObject, options) {
   'use strict';
+
   if (patternObject[options.cssCompiler]) {
     return createStyleArray(patternObject[options.cssCompiler], options.cssCompiler);
-  }
-  else if (patternObject.css) {
-    return createStyleArray(patternObject.css, 'css');
   }
   else {
     return false;

--- a/test/main.js
+++ b/test/main.js
@@ -232,7 +232,7 @@ describe('pattern utilities', function () {
 
     })
 
-    it('should default to css for pattern styles that do not match the default cssCompiler', function () {
+    it.skip('should default to css for pattern styles that do not match the default cssCompiler', function () {
 
       var file = utils.createFile(createTestFilePath('atoms/test-img/pattern.yml'));
       var patternObject = utils.convertYamlToObject(file.contents);
@@ -312,7 +312,7 @@ describe('pattern utilities', function () {
 
     });
 
-    it('should determine the destination for patterns without a default templateEngine file', function () {
+    it.skip('should determine the destination for patterns without a default templateEngine file', function () {
 
       var file = utils.createFile(createTestFilePath('atoms/test-em/pattern.yml'));
       var paths = utils.getFilePaths(file);


### PR DESCRIPTION
@e2tha-e 
cc: @rebmullin @sergesemashko @conortm @beynya @nikkiana
removing the ability to default to importing non-default files (html/css for example when using twig/scss)